### PR TITLE
IS-16338: Added validation_expression to webhooks

### DIFF
--- a/templates/contact.json
+++ b/templates/contact.json
@@ -101,7 +101,8 @@
     },
     "namespaced_identifiers": false,
     "source": {
-      "type": "http_endpoint"
+      "type": "http_endpoint",
+      "validation_expression": "{% if request_headers['X-Sesam-Authorization'] == secret('webhook_secret') %}{% else %}FAIL!{% endif %}"
     },
     "transform": [
       {

--- a/templates/customer.json
+++ b/templates/customer.json
@@ -202,7 +202,8 @@
     },
     "namespaced_identifiers": false,
     "source": {
-      "type": "http_endpoint"
+      "type": "http_endpoint",
+      "validation_expression": "{% if request_headers['X-Sesam-Authorization'] == secret('webhook_secret') %}{% else %}FAIL!{% endif %}"
     },
     "transform": [
       {

--- a/templates/employee.json
+++ b/templates/employee.json
@@ -101,7 +101,8 @@
     },
     "namespaced_identifiers": false,
     "source": {
-      "type": "http_endpoint"
+      "type": "http_endpoint",
+      "validation_expression": "{% if request_headers['X-Sesam-Authorization'] == secret('webhook_secret') %}{% else %}FAIL!{% endif %}"
     },
     "transform": [
       {

--- a/templates/invoice.json
+++ b/templates/invoice.json
@@ -94,7 +94,8 @@
     },
     "namespaced_identifiers": false,
     "source": {
-      "type": "http_endpoint"
+      "type": "http_endpoint",
+      "validation_expression": "{% if request_headers['X-Sesam-Authorization'] == secret('webhook_secret') %}{% else %}FAIL!{% endif %}"
     },
     "transform": [
       {

--- a/templates/order.json
+++ b/templates/order.json
@@ -101,7 +101,8 @@
     },
     "namespaced_identifiers": false,
     "source": {
-      "type": "http_endpoint"
+      "type": "http_endpoint",
+      "validation_expression": "{% if request_headers['X-Sesam-Authorization'] == secret('webhook_secret') %}{% else %}FAIL!{% endif %}"
     },
     "transform": [
       {

--- a/templates/system.json
+++ b/templates/system.json
@@ -487,8 +487,8 @@
     "webhook-insert": {
       "method": "POST",
       "payload": {
-        "authHeaderName": "Authorization",
-        "authHeaderValue": "Bearer $SECRET(service_jwt)",
+        "authHeaderName": "X-Sesam-Authorization",
+        "authHeaderValue": "$SECRET(webhook_secret)",
         "event": "{{ properties.event }}",
         "fields": "{{ properties.fields }}",
         "targetUrl": "{{ properties.targetUrl }}"


### PR DESCRIPTION
The webhooks now use the `X-Sesam-Authorization` header and the `webhook_secret` secret instead of a JWT token.